### PR TITLE
Fixed pilup_file argument parsing in merge_trf.py

### DIFF
--- a/reconstruction/reco/scripts/merge_trf.py
+++ b/reconstruction/reco/scripts/merge_trf.py
@@ -132,8 +132,9 @@ def run(args):
     else:
         args.input_file = [args.input_file]
 
+    args.pileup_file = Path(args.pileup_file)
     if not args.pileup_file.exists():
-        raise FileNotFoundError(f"Pileup input file {args.input_file} not found.")
+        raise FileNotFoundError(f"Pileup input file {args.pileup_file} not found.")
 
 
     pool = Parallel(n_jobs=args.number_of_threads)


### PR DESCRIPTION
This PR fixes the following error when running the `merge_trf.py` script:

```
Traceback (most recent call last):                                                                                                                             │
  File "/lorenzetti/build/scripts/reco/merge_trf.py", line 165, in <module>                                                           │
    run(args)                                                                                                                                                  │
  File "/lorenzetti/build/scripts/reco/merge_trf.py", line 135, in run                                                                │
    if not args.pileup_file.exists():                                                                                                                          │
AttributeError: 'str' object has no attribute 'exists'
```